### PR TITLE
Updating Tablet controller with new command schema

### DIFF
--- a/mirv_control/Controllers/command_examples/drivetrain.json
+++ b/mirv_control/Controllers/command_examples/drivetrain.json
@@ -1,0 +1,10 @@
+{
+    "command": "arcade",
+    "commandParameters": {
+        "x": 0.5,
+        "y": 0.5,
+        "runtimeType": "drivetrain"
+    },
+    "subsystem": "drivetrain",
+    "runtimeType": "drivetrainCommand"
+}

--- a/mirv_control/Controllers/command_examples/e_stop.json
+++ b/mirv_control/Controllers/command_examples/e_stop.json
@@ -1,0 +1,5 @@
+{
+    "command": "e_stop",
+    "subsystem": "general",
+    "runtimeType": "generalCommand"
+}

--- a/mirv_control/Controllers/tablet_controller.py
+++ b/mirv_control/Controllers/tablet_controller.py
@@ -38,7 +38,7 @@ def cloud_callback(json_string):
             drive = parameters.get('y', 0) * DRIVING_SCALE
             left = -drive + turn
             right = drive + turn
-            logging.debug(f"Sending drivetrain command to rover: left: {}")
+            logging.debug(f"Sending drivetrain command to rover: left: {left}, right: {right}")
             mirv.power_drive(left, right)
         elif command == "tank":
             left = parameters.get('x', 0) * DRIVING_SCALE

--- a/mirv_control/Controllers/tablet_controller.py
+++ b/mirv_control/Controllers/tablet_controller.py
@@ -3,34 +3,62 @@ import rospy
 from robot_controller import RobotController
 from std_msgs.msg import String
 import json
+import logging
 
 mirv = RobotController()
 
+
+DRIVING_SCALE = 0.5
+TURNING_SCALE = 0.5
+
+
 def cloud_callback(json_string):
-    drive = 0
-    turn = 0
+    if not json_string or not json_string.data:
+        return
 
-    commands = json.loads(json_string.data)
-    for key in commands:
-        if key == "joystick_x":
-            turn = commands[key]
-        if key == "joystick_y":
-            drive = commands[key]
-        if key == "intake":
-            mirv.set_intake_state(commands[key])
+    try:
+        commands = json.loads(json_string.data)
+    except ValueError:
+        logging.error(f"Unable to parse json from command: {json_string.data}")
+        return
 
-    left = -drive + turn
-    right = drive + turn
-    if "joystick_x" in commands or "joystick_y" in commands:
-        mirv.power_drive(left, right)
+    subsystem = commands.get('subsystem')
+    command = commands.get('command', '')
+    parameters = commands.get('parameters', {})
+
+    if subsystem == "general":
+        print('general')
+    elif subsystem == "intake":
+        print('intake')
+        mirv.set_intake_state(command)
+    elif subsystem == "drivetrain":
+        print('drivetrain')
+        if command == "arcade":
+            turn = parameters.get('x', 0) * TURNING_SCALE
+            drive = parameters.get('y', 0) * DRIVING_SCALE
+            left = -drive + turn
+            right = drive + turn
+            logging.debug(f"Sending drivetrain command to rover: left: {}")
+            mirv.power_drive(left, right)
+        elif command == "tank":
+            left = parameters.get('x', 0) * DRIVING_SCALE
+            right = parameters.get('y', 0) * DRIVING_SCALE
+            mirv.power_drive(left, right)
+        else:
+            logging.error(f"Invalid drivetrain command: {command}")
+    else:
+        logging.error(f"Invalid command subsystem: {subsystem}")
+
 
 def run():
     rospy.init_node("TabletDrive")
 
-    cloud_command_sub = rospy.Subscriber("CloudCommands", String, cloud_callback)
+    cloud_command_sub = rospy.Subscriber(
+        "CloudCommands", String, cloud_callback)
 
     while not rospy.is_shutdown():
         pass
+
 
 if __name__ == "__main__":
     run()


### PR DESCRIPTION
Updating tablet controller to accept new command schema: 
{"command": "e_stop", "subsystem": "general", "runtimeType": "generalCommand"}
- Adding logging
- Catching errors throughout
- Supporting arcade and tank drive modes