### PR TITLE
Updating pi-lit placement logic

### DIFF
--- a/mirv_control/RoverMaster/placement.py
+++ b/mirv_control/RoverMaster/placement.py
@@ -13,6 +13,7 @@ DEGREES_TO_RADIANS = math.pi / 180
 #                                                                                       |
 #                                                                                       |
 
+# Traffic Direction: >>>>
 
 # 5 Taper: Taper consisting of 5 pucks spaced at 10 feet longitudinally, equally spaced in the lane or shoulder laterally
 # | --------- | 10 feet                            | lane width
@@ -41,8 +42,6 @@ DEGREES_TO_RADIANS = math.pi / 180
 # width: lane width / (num Pi-lits - 1)
 # height: 10 feet
 # andle from longitudinal direction: +math.atan2(10ft, lane_width/(num_pi_lits - 1)) (negative if on right side of spear)
-
-
 def getEndPoint(lat1, lon1, bearing, d):
     R = 6371.0*1000  # Radius of the Earth in meters
     brng = math.radians(bearing)  # convert degrees to radians
@@ -58,46 +57,111 @@ def getEndPoint(lat1, lon1, bearing, d):
     return lat2, lon2
 
 
-# taper_right_3, taper_left_3, taper_right_5, taper_left_5, spear_7
-
-def generate_pi_lit_formation(lat_long, heading, lane_width, formation_type):
+###
+# detected_lanes: {'left': (lat, long), 'right': (lat, long)}
+# heading: global heading to place pi-lits in, relative to detected_lanes
+# lane_width: Width of lane, in meters
+# formation_type: enum of pi-lit formation type (taper_right_3, taper_left_3, taper_right_5, taper_left_5, spear_7)
+def generate_pi_lit_formation(detected_lanes, heading, lane_width, formation_type):
     if formation_type == "taper_right_3":
-        return taper_3(lat_long, heading, lane_width)
+        return taper_3(detected_lanes, heading, lane_width)
     elif formation_type == "taper_left_3":
-        return taper_3(lat_long, heading, lane_width, left_side=True)
+        return taper_3(detected_lanes, heading, lane_width, left_side=True)
     elif formation_type == "taper_right_5":
-        return taper_5(lat_long, heading, lane_width)
+        return taper_5(detected_lanes, heading, lane_width)
     elif formation_type == "taper_left_5":
-        return taper_5(lat_long, heading, lane_width, left_side=True)
+        return taper_5(detected_lanes, heading, lane_width, left_side=True)
     elif formation_type == "spear_7":
-        return spear_7(lat_long, heading, lane_width)
+        return spear_7(detected_lanes, heading, lane_width)
 
 
-def taper_3(lat_long, heading, lane_width, left_side=False):
-
-    lat, long = lat_long
-
-    # Start location: Left hand side, at start of formation
-    start_lat = lat
-    start_long = long
+def taper_3(detected_lanes, heading, lane_width, left_side=False):
+    start_lat_long = get_center_coordinates(
+        detected_lanes, heading, lane_width)
+    if start_lat_long == (None, None):
+        return []
 
     # Positive for to the right of start, negative for to the left of start
-    sign = -1 if left_side else -1
+    sign = -1 if left_side else 1
 
     # longitudinal_dist: longitudal distance from start point to pi-lit, in feet
     # lateral_dist: lateral (sideways) distance from the edge of the lane, in lane widths
     PI_LIT_LOCATIONS = [
-        {'longitudinal_dist': 10, 'lateral_dist': 0.128},
-        {'longitudinal_dist': 100, 'lateral_dist': 0.5},
-        {'longitudinal_dist': 200, 'lateral_dist': 0.5},
+        {'longitudinal_dist': 0, 'lateral_dist': 0.375 * sign},
+        {'longitudinal_dist': 100, 'lateral_dist': 0.0 * sign},
+        {'longitudinal_dist': 200, 'lateral_dist': 0.0 * sign},
     ]
 
+    return generate_pi_lit_locations(start_lat_long, heading, lane_width, PI_LIT_LOCATIONS)
+
+
+def taper_5(detected_lanes, heading, lane_width, left_side=False):
+    start_lat_long = get_center_coordinates(
+        detected_lanes, heading, lane_width)
+    if start_lat_long == (None, None):
+        return []
+
+    # Positive for to the right of start, negative for to the left of start
+    sign = -1 if left_side else 1
+
+    # longitudinal_dist: longitudal distance from start point to pi-lit, in feet
+    # lateral_dist: lateral (sideways) distance from the edge of the lane, in lane widths
+    PI_LIT_LOCATIONS = [
+        {'longitudinal_dist': 0,  'lateral_dist': 0.5 * sign},
+        {'longitudinal_dist': 10, 'lateral_dist': 0.25 * sign},
+        {'longitudinal_dist': 20, 'lateral_dist': 0.0 * sign},
+        {'longitudinal_dist': 30, 'lateral_dist': -0.25 * sign},
+        {'longitudinal_dist': 40, 'lateral_dist': -0.5 * sign},
+    ]
+
+    return generate_pi_lit_locations(start_lat_long, heading, lane_width, PI_LIT_LOCATIONS)
+
+
+def spear_7(detected_lanes, heading, lane_width, left_side=False):
+    start_lat_long = get_center_coordinates(
+        detected_lanes, heading, lane_width)
+    if start_lat_long == (None, None):
+        return []
+
+    # Positive for to the right of start, negative for to the left of start
+    sign = -1 if left_side else 1
+
+    # longitudinal_dist: longitudal distance from start point to pi-lit, in feet
+    # lateral_dist: lateral (sideways) distance from the edge of the lane, in lane widths
+    PI_LIT_LOCATIONS = [
+        {'longitudinal_dist': 0,  'lateral_dist': 0.5 * sign},
+        {'longitudinal_dist': 10, 'lateral_dist': 0.333 * sign},
+        {'longitudinal_dist': 20, 'lateral_dist': 0.167 * sign},
+        {'longitudinal_dist': 30, 'lateral_dist': 0 * sign},
+        {'longitudinal_dist': 20, 'lateral_dist': -0.167 * sign},
+        {'longitudinal_dist': 10, 'lateral_dist': -0.333 * sign},
+        {'longitudinal_dist': 0,  'lateral_dist': -0.5 * sign},
+    ]
+
+    return generate_pi_lit_locations(start_lat_long, heading, lane_width, PI_LIT_LOCATIONS)
+
+
+def get_center_coordinates(detected_lanes, heading, lane_width):
+    if len(detected_lanes.values()) == 2:
+        return (detected_lanes['left'][0] + detected_lanes['right']
+                [0], detected_lanes['left'][1] + detected_lanes['right'][1])
+    elif detected_lanes.get('left'):
+        return getEndPoint(
+            detected_lanes['left'][0], detected_lanes['left'][1], heading + 90, lane_width/2)
+    elif detected_lanes.get('right'):
+        return getEndPoint(
+            detected_lanes['right'][0], detected_lanes['right'][1], heading - 90, lane_width/2)
+    else:
+        return (None, None)
+
+
+def generate_pi_lit_locations(start_lat_long, heading, lane_width, distances):
+    start_lat, start_long = start_lat_long
     pi_lit_locations = []
-    for loc in PI_LIT_LOCATIONS:
+    for loc in distances:
         # Convert units
         longitudinal_dist_meters = loc['longitudinal_dist'] * FEET_TO_METERS
-        lateral_dist_meters = loc['lateral_dist'] * \
-            lane_width * FEET_TO_METERS * sign
+        lateral_dist_meters = loc['lateral_dist'] * lane_width
 
         # Generate angle and hypotenuse
         pi_lit_angle_relative = math.atan2(lateral_dist_meters,
@@ -112,85 +176,19 @@ def taper_3(lat_long, heading, lane_width, left_side=False):
 
         # Save value to array
         loc_rev = [location[0], location[1]]
+        loc_rev = [location[1], location[0]]
         pi_lit_locations.append(loc_rev)
-
-    return pi_lit_locations
-
-
-def taper_5(lat_long, heading, lane_width, left_side=False):
-    NUMBER_PI_LITS = 5
-    LONGITUDINAL_DISTANCE_METERS = 10 * FEET_TO_METERS
-    LATERAL_DISTANCE_METERS = lane_width / (NUMBER_PI_LITS - 1)
-
-    lat, long = lat_long
-
-    # Start location: Location of first Pi-Lit
-    start_lat = lat
-    start_long = long
-
-    sign = -1 if left_side else -1
-
-    pi_lit_angle_relative = sign * math.atan2(LATERAL_DISTANCE_METERS,
-                                              LONGITUDINAL_DISTANCE_METERS) * RADIANS_TO_DEGREES
-    pi_lit_angle = heading + pi_lit_angle_relative
-    pi_lit_distance = math.sqrt(
-        LONGITUDINAL_DISTANCE_METERS**2 + LATERAL_DISTANCE_METERS**2)
-
-    pi_lit_locations = [[start_lat, start_long]]
-    for i in range(1, NUMBER_PI_LITS):
-        location = getEndPoint(start_lat, start_long,
-                               pi_lit_angle, pi_lit_distance * i)
-        location = [location[0], location[1]]
-        pi_lit_locations.append(location)
-
-    return pi_lit_locations
-
-
-def spear_7(lat_long, heading, lane_width):
-    NUMBER_PI_LITS = 7
-    NUMBER_PI_LIT_LEFT = int((NUMBER_PI_LITS - 1) / 2 + 1)
-    NUMBER_PI_LIT_RIGHT = int((NUMBER_PI_LITS - 1) / 2 + 1)
-    LONGITUDINAL_DISTANCE_METERS = 10 * FEET_TO_METERS
-    LATERAL_DISTANCE_METERS = lane_width / (NUMBER_PI_LITS - 1)
-
-    lat, long = lat_long
-
-    # Start location: Left hand side, at start of formation
-    start_lat = lat
-    start_long = long
-
-    pi_lit_angle_relative = math.atan2(LATERAL_DISTANCE_METERS,
-                                       LONGITUDINAL_DISTANCE_METERS) * RADIANS_TO_DEGREES
-    pi_lit_angle_start = heading + pi_lit_angle_relative  # Start from left-hand side
-    pi_lit_angle_end = heading - pi_lit_angle_relative - 180
-    pi_lit_distance = math.sqrt(
-        LONGITUDINAL_DISTANCE_METERS**2 + LATERAL_DISTANCE_METERS**2)
-
-    pi_lit_locations = [[start_lat, start_long]]
-    for i in range(1, NUMBER_PI_LIT_LEFT):
-        location = getEndPoint(start_lat, start_long,
-                               pi_lit_angle_start, pi_lit_distance * i)
-        location = [location[0], location[1]]
-        pi_lit_locations.append(location)
-
-    point_lat = pi_lit_locations[-1][0]
-    point_long = pi_lit_locations[-1][1]
-    for i in range(1, NUMBER_PI_LIT_RIGHT):
-        location = getEndPoint(point_lat, point_long,
-                               pi_lit_angle_end, pi_lit_distance * i)
-        location = [location[0], location[1]]
-        pi_lit_locations.append(location)
-
     return pi_lit_locations
 
 
 def test():
-    lat = 40.47411757814349
-    long = -104.9694349989295
-    heading = 45
-    lane_width = 3
-    lane_type = "taper_right_3"
-    print(generate_pi_lit_formation((lat, long), heading, lane_width, lane_type))
+    rover_lat = 40.47413211566721
+    rover_long = -104.96944840997458
+    detected_lanes = {'right': (rover_lat, rover_long)}
+    heading = 225  # Opposite traffic direction
+    lane_width = 3  # meters
+    lane_type = "spear_7"
+    print(generate_pi_lit_formation(detected_lanes, heading, lane_width, lane_type))
 
 
 if __name__ == "__main__":

--- a/mirv_control/RoverMaster/placement.py
+++ b/mirv_control/RoverMaster/placement.py
@@ -143,8 +143,8 @@ def spear_7(detected_lanes, heading, lane_width, left_side=False):
 
 def get_center_coordinates(detected_lanes, heading, lane_width):
     if len(detected_lanes.values()) == 2:
-        return (detected_lanes['left'][0] + detected_lanes['right']
-                [0], detected_lanes['left'][1] + detected_lanes['right'][1])
+        return ((detected_lanes['left'][0] + detected_lanes['right']
+                [0])/2, (detected_lanes['left'][1] + detected_lanes['right'][1])/2)
     elif detected_lanes.get('left'):
         return getEndPoint(
             detected_lanes['left'][0], detected_lanes['left'][1], heading + 90, lane_width/2)
@@ -182,9 +182,9 @@ def generate_pi_lit_locations(start_lat_long, heading, lane_width, distances):
 
 
 def test():
-    rover_lat = 40.47413211566721
-    rover_long = -104.96944840997458
-    detected_lanes = {'right': (rover_lat, rover_long)}
+    lat_long_right = (40.47413211566721, -104.96944840997458)
+    lat_long_left = (40.474113038173684, -104.96942333108585)
+    detected_lanes = {'right': lat_long_right, 'left': lat_long_left}
     heading = 225  # Opposite traffic direction
     lane_width = 3  # meters
     lane_type = "spear_7"


### PR DESCRIPTION
Adding detected_lanes object, which declares left and right detected lane locations. If both are specified, it will average them for the center, otherwise it will use the heading and lane width to find the estimated lane center location

example call:
```
rover_lat = 40.47413211566721
rover_long = -104.96944840997458
detected_lanes = {'right': (rover_lat, rover_long)}
heading = 225  # Opposite traffic direction
lane_width = 3  # meters
lane_type = "spear_7"
print(generate_pi_lit_formation(detected_lanes, heading, lane_width, lane_type))
```